### PR TITLE
Feature 23: Add explicit dependency on behat/mink-selenium2-driver with revised alias

### DIFF
--- a/build-project.sh
+++ b/build-project.sh
@@ -16,7 +16,7 @@ php build-composer-file.php
 ## Replace all occurrences of "web" with "docroot" in the .gitignore file.
 sed -i 's/web/docroot/' drupal/.gitignore
 ## Add packages to composer.json file for this project.
-composer require "behat/mink-selenium2-driver" --dev --working-dir=drupal --no-update
+composer require "behat/mink-selenium2-driver:1.4.x-dev as 1.3.x-dev" --dev --working-dir=drupal --no-update
 composer require "drupal/drupal-extension:^4.0@beta" --dev --working-dir=drupal --no-update
 composer require "guzzlehttp/guzzle:^6.0@dev" --dev --working-dir=drupal --no-update
 composer require "phpunit/phpunit:>=4.8.24" --dev --working-dir=drupal --no-update


### PR DESCRIPTION
#23 

https://github.com/minkphp/MinkSelenium2Driver/issues/313

Branch alias for master was changed from 1.3.x-dev to 1.4.x-dev.

This PR adds an explicit declaration for behat/mink-selenium2-driver, mapping
1.4.x-dev to 1.3.x-dev as an alias.

This is a temporary fix until Drupal Core corrects this issue (see above minkphp project
issue for more details)

On branch feature-23-mink-selenium2-explicit-dependency

Changes to be committed:
	modified:   build-project.sh